### PR TITLE
write_graphite plugin: Fix locking.

### DIFF
--- a/src/write_graphite.c
+++ b/src/write_graphite.c
@@ -116,20 +116,15 @@ static int wg_send_buffer (struct wg_callback *cb)
                 status,
                 strerror (errno));
 
-        pthread_mutex_trylock (&cb->send_lock);
-
-        DEBUG ("write_graphite plugin: closing socket and restting fd "
-                "so reinit will occur");
         close (cb->sock_fd);
         cb->sock_fd = -1;
-
-        pthread_mutex_unlock (&cb->send_lock);
 
         return (-1);
     }
     return (0);
 }
 
+/* NOTE: You must hold cb->send_lock when calling this function! */
 static int wg_flush_nolock (cdtime_t timeout, struct wg_callback *cb)
 {
     int status;
@@ -236,13 +231,19 @@ static void wg_callback_free (void *data)
 
     cb = data;
 
+    pthread_mutex_lock (&cb->send_lock);
+
     wg_flush_nolock (/* timeout = */ 0, cb);
 
     close(cb->sock_fd);
+    cb->sock_fd = -1;
+
     sfree(cb->node);
     sfree(cb->service);
     sfree(cb->prefix);
     sfree(cb->postfix);
+
+    pthread_mutex_destroy (&cb->send_lock);
 
     sfree(cb);
 }


### PR DESCRIPTION
_wg_send_buffer()_ is called from _wg_flush_nolock()_. When calling _wg_flush_nolock()_, the thread has to hold _cb->send_lock_. Locking it again will fail, but this condition is not checked for. Then the lock is released twice which may result in concurrency issues.
